### PR TITLE
advanced edge configurations

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -206,19 +206,26 @@
                 <span class="id">id="viewtrack-1"</span>
             </div>
 
-            <div class="demo" ui-scrollpoint="{{scrollpoint}}" ui-scrollpoint-action="reportScroll">
-                ui-scrollpoint="{{scrollpoint}}"<br/>
+            <div class="demo" ui-scrollpoint ui-scrollpoint-edge="{ top: '-25', bottom: '+25' }" ui-scrollpoint-action="reportScroll">
+                ui-scrollpoint<br/>
+                ui-scrollpoint-edge="{ top: '-25', bottom: '+25' }"<br/>
                 ui-scrollpoint-action="reportScroll"
             </div>
 
-            <div class="demo" ui-scrollpoint="{{scrollpoint}}" ui-scrollpoint-class="my-scrollpoint">
+            <div class="demo" ui-scrollpoint="{{scrollpoint}}" ui-scrollpoint-edge="['top', 'bottom']" ui-scrollpoint-class="my-scrollpoint">
                 ui-scrollpoint="{{scrollpoint}}"<br/>
+                ui-scrollpoint-edge="['top', 'bottom']"<br/>
                 ui-scrollpoint-class="my-scrollpoint"
             </div>
 
             <div class="demo" ui-scrollpoint="{{scrollpoint}}" ui-scrollpoint-class="ui-scrollpoint another-scrollpoint">
                 ui-scrollpoint="{{scrollpoint}}"<br/>
                 ui-scrollpoint-class="ui-scrollpoint another-scrollpoint"
+            </div>
+
+            <div class="demo" ui-scrollpoint ui-scrollpoint-edge="{ top: '25%', bottom: '70%' }">
+                ui-scrollpoint<br/>
+                ui-scrollpoint-edge="{ top: '25%', bottom: '70%' }"
             </div>
 
             <br style="clear:both;"/>
@@ -391,7 +398,6 @@
                 </div>
             </div>
 
-
             <div class="demo" ui-scrollpoint ui-scrollpoint-edge="bottom">
                 ui-scrollpoint<br/>
                 ui-scrollpoint-edge="bottom"
@@ -416,6 +422,28 @@
                 ui-scrollpoint="+25"<br/>
                 ui-scrollpoint-edge="bottom"<br/>
                 ui-scrollpoint-action="reportScroll"
+            </div>
+
+            <div class="demo" ui-scrollpoint ui-scrollpoint-edge="bottom">
+                ui-scrollpoint<br/>
+                ui-scrollpoint-edge="bottom"
+            </div>
+
+            <div class="demo" ui-scrollpoint ui-scrollpoint-edge="{ top: '-25', bottom: '+25' }">
+                ui-scrollpoint<br/>
+                ui-scrollpoint-edge="{ top: '-25', bottom: '+25' }"
+            </div>
+
+            <div class="demo" ui-scrollpoint="{{scrollpoint}}" ui-scrollpoint-edge="['bottom', 'top']" ui-scrollpoint-class="my-scrollpoint">
+                ui-scrollpoint="{{scrollpoint}}"<br/>
+                ui-scrollpoint-edge="['bottom', 'top']"<br/>
+                ui-scrollpoint-class="my-scrollpoint"
+            </div>
+
+            <div class="demo" ui-scrollpoint="{{scrollpoint}}" ui-scrollpoint-edge="bottom" ui-scrollpoint-class="ui-scrollpoint another-scrollpoint">
+                ui-scrollpoint="{{scrollpoint}}"<br/>
+                ui-scrollpoint-edge="bottom"<br/>
+                ui-scrollpoint-class="ui-scrollpoint another-scrollpoint"
             </div>
 
             <br style="clear:both;"/>

--- a/demo/index.html
+++ b/demo/index.html
@@ -58,30 +58,21 @@
                     relative: { x: 15, y: 0 }
                 };
 
+                function resetScrollpoint(){
+                    $scope.$broadcast('scrollpointShouldReset');
+                }
+
                 // watch toggle controls
-                $scope.$watchGroup(['topSpacer', 'showAbsolute', 'shiftRelative', 'target.showAbsolute', 'target.showRelative'], 
-                    function(){
-                        $scope.$broadcast('scrollpointShouldReset');
-                    });
+                $scope.$watchGroup(['topSpacer', 'showAbsolute', 'shiftRelative', 'target.showAbsolute', 'target.showRelative'], resetScrollpoint);
 
                 // watch co-ordinate collections
-                $scope.$watchCollection('absolute', function(){
-                    $scope.$broadcast('scrollpointShouldReset');
-                });
-                $scope.$watchCollection('relative', function(){
-                    $scope.$broadcast('scrollpointShouldReset');
-                });
-                $scope.$watchCollection('target.absolute', function(){
-                    $scope.$broadcast('scrollpointShouldReset');
-                });
-                $scope.$watchCollection('target.relative', function(){
-                    $scope.$broadcast('scrollpointShouldReset');
-                });
+                $scope.$watchCollection('absolute', resetScrollpoint);
+                $scope.$watchCollection('relative', resetScrollpoint);
+                $scope.$watchCollection('target.absolute', resetScrollpoint);
+                $scope.$watchCollection('target.relative', resetScrollpoint);
 
                 // initialize
-                $timeout(function(){
-                    $scope.$broadcast('scrollpointShouldReset');
-                }, 10);
+                $timeout( resetScrollpoint, 10 );
                 
             });
         </script>

--- a/src/scrollpoint.js
+++ b/src/scrollpoint.js
@@ -26,12 +26,14 @@ angular.module('ui.scrollpoint', []).directive('uiScrollpoint', ['$window', '$ti
                 this.$target = undefined;
                 this.hasTarget = false;
 
-                this.edges = {top: true};
+                this.edges = { top: { top: null }}; // ui-scrollpoint on top edge of element with top edge of target
                 this.hitEdge = undefined;
 
-                this.absolute = true;
-                this.percent = false;
-                this.shift = 0;
+                this.default_edge = {
+                    absolute: false,
+                    percent: false,
+                    shift: 0
+                };
                 this.posCache = {};
 
                 this.enabled = true;
@@ -39,16 +41,77 @@ angular.module('ui.scrollpoint', []).directive('uiScrollpoint', ['$window', '$ti
                 this.scrollpointClass = 'ui-scrollpoint';
                 this.actions = undefined;
 
+                function parseScrollpoint(scrollpoint){
+                    var def = { shift: 0, absolute: false, percent: false };
+                    if(scrollpoint && angular.isString(scrollpoint)) {
+                        def.percent = (scrollpoint.charAt(scrollpoint.length-1) == '%');
+                        if(def.percent) {
+                            scrollpoint = scrollpoint.substr(0, scrollpoint.length-1);
+                        }
+                        if(scrollpoint.charAt(0) === '-') {
+                            def.absolute = def.percent;
+                            def.shift = -parseFloat(scrollpoint.substr(1));
+                        }
+                        else if(scrollpoint.charAt(0) === '+') {
+                            def.absolute = def.percent;
+                            def.shift = parseFloat(scrollpoint.substr(1));
+                        }
+                        else {
+                            var parsed = parseFloat(scrollpoint);
+                            if (!isNaN(parsed) && isFinite(parsed)) {
+                                def.absolute = true;
+                                def.shift = parsed;
+                            }
+                        }
+                    }
+                    else if(angular.isNumber(scrollpoint)){
+                        return parseScrollpoint(scrollpoint.toString());
+                    }
+                    return def;
+                }
+
                 this.addEdge = function(view_edge, element_edge){
                     if(angular.isString(view_edge)){
                         if(angular.isUndefined(element_edge)){
                             element_edge = true;
                         }
                         if(view_edge == 'view'){
+                            // view is a shorthand for matching top of element with bottom of view, and vice versa
                             this.addEdge('top', 'bottom');
                             this.addEdge('bottom', 'top');
                         }
                         else{
+                            var edge, parsedEdge;
+                            if(angular.isObject(element_edge)){
+                                // the view_edge interacts with more than one element_edge
+                                for(edge in element_edge){
+                                    // parse each element_edge definition (allows each element_edge to have its own scrollpoint with view_edge)
+                                    if(element_edge[edge] === true){
+                                        element_edge[edge] = null; // use the ui-scrollpoint default
+                                    }
+                                    else{
+                                        element_edge[edge] = parseScrollpoint(element_edge[edge]);
+                                    }
+                                }
+                            }
+                            else if(element_edge == 'top' || element_edge == 'bottom'){
+                                // simple top or bottom of element with 0 shift
+                                edge = element_edge;
+                                parsedEdge = parseScrollpoint();
+                                element_edge = {};
+                                element_edge[edge] = parsedEdge;
+                            }
+                            else if(element_edge === true){
+                                element_edge = {};
+                                element_edge[view_edge] = null; // use the ui-scrollpoint default
+                            }
+                            else{
+                                // element_edge matches view_edge (ie. top of element interacts with top of view)
+                                parsedEdge = parseScrollpoint(element_edge);
+                                element_edge = {};
+                                element_edge[view_edge] = parsedEdge;
+                            }
+                            // element_edge has been parsed
                             this.edges[view_edge] = element_edge;
                         }
                     }
@@ -66,33 +129,7 @@ angular.module('ui.scrollpoint', []).directive('uiScrollpoint', ['$window', '$ti
                 };
 
                 this.setScrollpoint = function(scrollpoint){
-                    if (!scrollpoint) {
-                        this.absolute = false;
-                        this.percent = false;
-                        this.shift = 0;
-                    } else if (typeof (scrollpoint) === 'string') {
-                        // charAt is generally faster than indexOf: http://jsperf.com/indexof-vs-charat
-                        this.percent = (scrollpoint.charAt(scrollpoint.length-1) == '%');
-                        if(this.percent){
-                            scrollpoint = scrollpoint.substr(0, scrollpoint.length-1);
-                        }
-                        if (scrollpoint.charAt(0) === '-') {
-                            this.absolute = this.percent;
-                            this.shift = -parseFloat(scrollpoint.substr(1));
-                        } else if (scrollpoint.charAt(0) === '+') {
-                            this.absolute = this.percent;
-                            this.shift = parseFloat(scrollpoint.substr(1));
-                        } else {
-                            var parsed = parseFloat(scrollpoint);
-                            if (!isNaN(parsed) && isFinite(parsed)) {
-                                this.absolute = true;
-                                this.shift = parsed;
-                            }
-                        }
-                    } else if (typeof (scrollpoint) === 'number') {
-                        this.setScrollpoint(scrollpoint.toString());
-                        return;
-                    }
+                    this.default_edge = parseScrollpoint(scrollpoint);
                 };
 
                 this.setClass = function(_class){
@@ -123,7 +160,8 @@ angular.module('ui.scrollpoint', []).directive('uiScrollpoint', ['$window', '$ti
                     }
                     else{
                         // default
-                        this.edges = {top: true};
+                        this.edges = {};
+                        this.addEdge('top');
                     }
                 };
 
@@ -142,63 +180,94 @@ angular.module('ui.scrollpoint', []).directive('uiScrollpoint', ['$window', '$ti
                     }
                 };
 
-                this.scrollEdgeHit = function(){
-                    var offset, hitEdge, flipOffset;
-                    for(var scroll_edge in this.edges){
-                        var scroll_top = (scroll_edge == 'top');
-                        var scroll_bottom = (scroll_edge == 'bottom');
+                this.checkOffset = function(scroll_edge, elem_edge, edge){
+                    var offset;
+                    if(!edge){
+                        edge = this.default_edge;
+                    }
 
-                        var elem_edge = this.edges[scroll_edge];
-                        var elem_top = (elem_edge == 'top');
-                        var elem_bottom = (elem_edge == 'bottom');
-                        if(elem_edge === true){
-                            if(scroll_top){ elem_top = true; }
-                            if(scroll_bottom){ elem_bottom = true; }
-                        }
+                    var scroll_bottom = (scroll_edge == 'bottom');
+                    var elem_top = (elem_edge == 'top');
+                    var elem_bottom = (elem_edge == 'bottom');
 
-                        var scrollOffset = this.getScrollOffset();
-                        if(scroll_bottom){
-                            scrollOffset += this.getTargetHeight();
-                        }
+                    var scrollOffset = this.getScrollOffset();
+                    if(scroll_bottom){
+                        scrollOffset += this.getTargetHeight();
+                    }
 
-                        var checkOffset;
-                        if(this.absolute){
-                            if(this.percent){
-                                checkOffset = this.shift / 100.0 * this.getTargetScrollHeight();
-                            }
-                            else{
-                                checkOffset = this.shift;
-                            }
-                            if(scroll_bottom){
-                                checkOffset = this.getTargetContentHeight() - checkOffset;
-                                if(this.hasTarget){
-                                    checkOffset += this.getTargetHeight();
-                                }
-                            }
+                    var checkOffset;
+                    if(edge.absolute){
+                        if(edge.percent){
+                            checkOffset = edge.shift / 100.0 * this.getTargetScrollHeight();
                         }
                         else{
-                            if(elem_top){
-                                checkOffset = this.getElementTop();
-                            }
-                            else if(elem_bottom){
-                                checkOffset = this.getElementBottom();
-                            }
-                            checkOffset += this.shift;
+                            checkOffset = edge.shift;
                         }
-                        
-                        var edge_offset = (scrollOffset - checkOffset);
                         if(scroll_bottom){
-                            edge_offset *= -1.0;
+                            checkOffset = this.getTargetContentHeight() - checkOffset;
+                            if(this.hasTarget){
+                                checkOffset += this.getTargetHeight();
+                            }
                         }
+                    }
+                    else{
+                        if(elem_top){
+                            checkOffset = this.getElementTop();
+                        }
+                        else if(elem_bottom){
+                            checkOffset = this.getElementBottom();
+                        }
+                        checkOffset += edge.shift;
+                    }
 
-                        if(angular.isUndefined(offset) || edge_offset > offset){
-                            offset = edge_offset;
-                            hitEdge = scroll_edge;
-                            flipOffset = (scroll_bottom && this.absolute);
+                    offset = (scrollOffset - checkOffset);
+                    if(scroll_bottom){
+                        offset *= -1.0;
+                    }
+                    return offset;
+                };
+
+                this.scrollEdgeHit = function(){
+                    var offset, hitEdge;
+                    var edge, absEdges;
+                    for(var scroll_edge in this.edges){
+                        for(var element_edge in this.edges[scroll_edge]){
+                            edge = (this.edges[scroll_edge][element_edge] ? this.edges[scroll_edge][element_edge] : this.default_edge);
+                            var edge_offset = this.checkOffset(scroll_edge, element_edge, edge);
+
+                            if(edge.absolute){
+                                if(angular.isUndefined(absEdges)){
+                                    absEdges = {};
+                                }
+                                absEdges[scroll_edge] = edge_offset;
+                            }
+                            else if(angular.isUndefined(offset) || edge_offset > offset){
+                                offset = edge_offset;
+                                hitEdge = scroll_edge;
+                            }
+                        }
+                    }
+                    // special handling for absolute edges when no relative edges hit
+                    if(absEdges && !hitEdge){
+                        // in case there is more than one absolute edge, they all should pass to count a hit (allows for creating ranges where the scrollpoint is active)
+                        var allPass = true;
+                        offset = undefined;
+                        for(edge in absEdges){
+                            if(absEdges[edge] < 0){
+                                allPass = false;
+                            }
+                            else if(angular.isUndefined(offset) || absEdges[edge] > offset){
+                                offset = absEdges[edge];
+                                hitEdge = edge;
+                            }
+                        }
+                        if(!allPass){
+                            hitEdge = undefined;
+                            offset = undefined;
                         }
                     }
                     this.hitEdge = (offset >= 0) ? hitEdge : undefined;
-                    return offset*(flipOffset?-1.0:1.0);
+                    return offset;
                 };
 
                 this.getScrollOffset = function(){
@@ -249,7 +318,7 @@ angular.module('ui.scrollpoint', []).directive('uiScrollpoint', ['$window', '$ti
                 // base ui-scrollpoint (leave blank or set to: absolute, +, -, or %)
                 attrs.$observe('uiScrollpoint', function(scrollpoint){
                     uiScrollpoint.setScrollpoint(scrollpoint);
-                    onScroll();
+                    reset();
                 });
 
                 // ui-scrollpoint-enabled allows disabling the scrollpoint
@@ -285,9 +354,9 @@ angular.module('ui.scrollpoint', []).directive('uiScrollpoint', ['$window', '$ti
 
                 // ui-scrollpoint-class class to add instead of ui-scrollpoint
                 attrs.$observe('uiScrollpointClass', function(scrollpointClass){
+                    elm.removeClass(uiScrollpoint.scrollpointClass);
                     uiScrollpoint.setClass(scrollpointClass);
-                    hit = false;
-                    onScroll();
+                    reset();
                 });
 
                 // ui-scrollpoint-edge allows configuring which element and scroll edges match
@@ -302,6 +371,7 @@ angular.module('ui.scrollpoint', []).directive('uiScrollpoint', ['$window', '$ti
 
                         // assign it in controller
                         uiScrollpoint.setEdges(scrollpointEdge);
+                        reset();
                     }
                 });
     

--- a/src/scrollpoint.js
+++ b/src/scrollpoint.js
@@ -26,7 +26,7 @@ angular.module('ui.scrollpoint', []).directive('uiScrollpoint', ['$window', '$ti
                 this.$target = undefined;
                 this.hasTarget = false;
 
-                this.edges = { top: { top: null }}; // ui-scrollpoint on top edge of element with top edge of target
+                this.edges = { top: { top: true }}; // ui-scrollpoint on top edge of element with top edge of target
                 this.hitEdge = undefined;
 
                 this.default_edge = {
@@ -87,7 +87,7 @@ angular.module('ui.scrollpoint', []).directive('uiScrollpoint', ['$window', '$ti
                                 for(edge in element_edge){
                                     // parse each element_edge definition (allows each element_edge to have its own scrollpoint with view_edge)
                                     if(element_edge[edge] === true){
-                                        element_edge[edge] = null; // use the ui-scrollpoint default
+                                        element_edge[edge] = true; // use the ui-scrollpoint default
                                     }
                                     else{
                                         element_edge[edge] = parseScrollpoint(element_edge[edge]);
@@ -103,7 +103,7 @@ angular.module('ui.scrollpoint', []).directive('uiScrollpoint', ['$window', '$ti
                             }
                             else if(element_edge === true){
                                 element_edge = {};
-                                element_edge[view_edge] = null; // use the ui-scrollpoint default
+                                element_edge[view_edge] = true; // use the ui-scrollpoint default
                             }
                             else{
                                 // element_edge matches view_edge (ie. top of element interacts with top of view)
@@ -182,7 +182,7 @@ angular.module('ui.scrollpoint', []).directive('uiScrollpoint', ['$window', '$ti
 
                 this.getEdge = function(scroll_edge, element_edge){
                     if(scroll_edge && element_edge){
-                        if(this.edges[scroll_edge] && this.edges[scroll_edge][element_edge]){
+                        if(this.edges[scroll_edge] && this.edges[scroll_edge][element_edge] && this.edges[scroll_edge][element_edge] !== true){
                             return this.edges[scroll_edge][element_edge];
                         }
                     }


### PR DESCRIPTION
Allows specifying different offsets for top and bottom.

examples:

Activate within 25 pixels of top or bottom of target:
`<div ui-scrollpoint ui-scrollpoint-edge="{'top': '-25', 'bottom': '+25'}"></div>`

Active when scrolled between 25% from top and 25px from bottom
`<div ui-scrollpoint ui-scrollpoint-edge="{'top': '25%', 'bottom': '25'}"></div>`
