### PR TITLE
Add CDN usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ Add the specific module to your dependencies:
 angular.module('myApp', ['ui.scrollpoint', ...])
 ```
 
+Alternatively, include it via CDN
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/angular@1/angular.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/angular-ui-scrollpoint@2/dist/scrollpoint.min.js"></script>
+```
+
 ## Development
 
 We use Karma and jshint to ensure the quality of the code.  The easiest way to run these checks is to use grunt:


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/angular-ui-scrollpoint) to your readme to make it easier to use. jsDelivr is the fastest opensource CDN available and built specifically for production usage.